### PR TITLE
Conserta ProductForm mandando PATCH quando não deve

### DIFF
--- a/public/js/product/create.js
+++ b/public/js/product/create.js
@@ -401,7 +401,7 @@ var ProductForm = function ProductForm(props) {
     className: styles.container,
     method: "post",
     action: product ? '/product/' + product.id : '/product'
-  }, react_1["default"].createElement(CSRF_1["default"], null), react_1["default"].createElement("input", {
+  }, react_1["default"].createElement(CSRF_1["default"], null), product && react_1["default"].createElement("input", {
     type: "hidden",
     name: "_method",
     value: "PATCH"

--- a/public/js/product/edit.js
+++ b/public/js/product/edit.js
@@ -401,7 +401,7 @@ var ProductForm = function ProductForm(props) {
     className: styles.container,
     method: "post",
     action: product ? '/product/' + product.id : '/product'
-  }, react_1["default"].createElement(CSRF_1["default"], null), react_1["default"].createElement("input", {
+  }, react_1["default"].createElement(CSRF_1["default"], null), product && react_1["default"].createElement("input", {
     type: "hidden",
     name: "_method",
     value: "PATCH"

--- a/public/js/product/index.js
+++ b/public/js/product/index.js
@@ -401,7 +401,7 @@ var ProductForm = function ProductForm(props) {
     className: styles.container,
     method: "post",
     action: product ? '/product/' + product.id : '/product'
-  }, react_1["default"].createElement(CSRF_1["default"], null), react_1["default"].createElement("input", {
+  }, react_1["default"].createElement(CSRF_1["default"], null), product && react_1["default"].createElement("input", {
     type: "hidden",
     name: "_method",
     value: "PATCH"

--- a/resources/js/components/ProductForm.tsx
+++ b/resources/js/components/ProductForm.tsx
@@ -15,7 +15,9 @@ const ProductForm : React.FC<Props> = (props) => {
     return (
         <form className={styles.container} method="post" action={product ? '/product/' + product.id : '/product'}>
             <CSRF/>
-            <input type="hidden" name="_method" value="PATCH"/>
+            {product &&
+                <input type="hidden" name="_method" value="PATCH"/>
+            }
             <input className={styles.input} type="text" name="name" defaultValue={product?.name} placeholder="Insira nome do produto"/> <br/>
             <input className={styles.input} type="number" step="0.01" name="price" defaultValue={product?.price} placeholder="Insira o preço do produto"/> <br/>
             <textarea className={styles.input + ' ' + styles.txtDescription} name="description" defaultValue={product?.description} placeholder="Insira descrição do produto"/> <br/>


### PR DESCRIPTION
Foi deixado um input para method spoofing para PATCH em ProductForm, até quando ProductForm era usado como formulário de cadastro, essa PR resolve isso.