### PR TITLE
Adiciona proteção de text overflow em ProductPod

### DIFF
--- a/public/js/product/index.js
+++ b/public/js/product/index.js
@@ -678,7 +678,7 @@ var ProductPod = function ProductPod(props) {
     className: styles.container
   }, react_1["default"].createElement("div", null, react_1["default"].createElement("div", {
     className: styles.txtName
-  }, product.name + ' - R$' + product.price.toFixed(2)), react_1["default"].createElement("div", {
+  }, (product.name.length <= 25 ? product.name : product.name.substring(0, 25) + '...') + ' - R$' + product.price.toFixed(2)), react_1["default"].createElement("div", {
     className: styles.txtDescription
   }, product.description.length <= 50 ? product.description : product.description.substring(0, 50) + '...')), react_1["default"].createElement("div", {
     className: styles.btnGroup

--- a/resources/js/components/ProductPod.tsx
+++ b/resources/js/components/ProductPod.tsx
@@ -17,8 +17,8 @@ const ProductPod : React.FC<Props> = (props) => {
     return (
         <div className={styles.container}>
             <div>
-                <div className={styles.txtName}>{product.name + ' - R$' + product.price.toFixed(2)}</div>
-                <div className={styles.txtDescription}>{product.description}</div>
+                <div className={styles.txtName}>{(product.name.length <= 25 ? product.name : product.name.substring(0, 25) + '...') + ' - R$' + product.price.toFixed(2)}</div>
+                <div  className={styles.txtDescription}>{product.description.length <= 50 ? product.description : product.description.substring(0, 50) + '...'}</div>
             </div>
             <div className={styles.btnGroup}>
                 <button className={styles.btn} onClick={props.onBtnEditPress}>


### PR DESCRIPTION
Se um texto é muito grande em ProductPod, ele acaba esticando toda a tela e fica impossível de visualizar o resto do conteúdo. Essa PR resolve isso.